### PR TITLE
Adding support for iPad as well.

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -50,7 +50,9 @@ function search (opts) {
       opts.requestOptions
     )
       .then(JSON.parse)
-      .then((response) => (response.bubbles[0] && response.bubbles[0].results) || [])
+      .then((response) => {
+        return (response.bubbles[0] && response.bubbles[0].results) || (response.pageData.bubbles[0] && response.pageData.bubbles[0].results) || []
+      })
       .then(paginate(opts.num, opts.page))
       .then(R.pluck('id'))
       .then((ids) => {

--- a/lib/search.js
+++ b/lib/search.js
@@ -23,11 +23,11 @@ function search (opts) {
     const url = BASE_URL + encodeURIComponent(opts.term);
     const storeId = common.storeId(opts.country);
     const lang = opts.lang || 'en-us';
-
+    const platformId = opts.platform === 'ipad' ? 25 : 24;
     common.request(
       url,
       {
-        'X-Apple-Store-Front': `${storeId},24 t:native`,
+        'X-Apple-Store-Front': `${storeId},${platformId} t:native`,
         'Accept-Language': lang
       },
       opts.requestOptions

--- a/lib/search.js
+++ b/lib/search.js
@@ -51,7 +51,7 @@ function search (opts) {
     )
       .then(JSON.parse)
       .then((response) => {
-        return (response.bubbles[0] && response.bubbles[0].results) || (response.pageData.bubbles[0] && response.pageData.bubbles[0].results) || []
+        return (response.bubbles && response.bubbles.length > 0 && response.bubbles[0].results) || (response.pageData && response.pageData.bubbles.length > 0  && response.pageData.bubbles[0].results) || []
       })
       .then(paginate(opts.num, opts.page))
       .then(R.pluck('id'))

--- a/lib/search.js
+++ b/lib/search.js
@@ -23,6 +23,23 @@ function search (opts) {
     const url = BASE_URL + encodeURIComponent(opts.term);
     const storeId = common.storeId(opts.country);
     const lang = opts.lang || 'en-us';
+    // The platformId is not well documented but this is what
+    // I have gathered so far and will be digging in more as I have time
+    /*
+    {
+      K7: 20,  // iPad
+      P7: 21,  // iPhone
+      K71: 23, // iPad
+      P71: 24, // iPhone
+      K8: 25,  // iPad
+      P8: 26,  // iPhone
+      P84: 29, // iPhone
+      K84: 30, // iPad
+      Android: 31,
+      Watch: 35,
+      MacPodcasts1: 38
+    }
+    */
     const platformId = opts.platform === 'ipad' ? 25 : 24;
     common.request(
       url,


### PR DESCRIPTION
Keyword search is platform specific and needs a different platform id when searching keywords for iPad apps